### PR TITLE
Add production OAuth URLs for Feide integration

### DIFF
--- a/amplify/auth/resource.ts
+++ b/amplify/auth/resource.ts
@@ -1,4 +1,4 @@
-import { defineAuth } from "@aws-amplify/backend";
+import { defineAuth, secret } from "@aws-amplify/backend";
 import { postConfirmation } from "./post-confirmation/resource";
 import { preSignUp } from "./pre-sign-up/resource";
 import { defineAuthChallenge } from "./define-auth-challenge/resource";
@@ -8,6 +8,29 @@ import { verifyAuthChallenge } from "./verify-auth-challenge/resource";
 export const auth = defineAuth({
   loginWith: {
     email: true,
+    externalProviders: {
+      oidc: [
+        {
+          name: "Feide",
+          clientId: secret("FEIDE_CLIENT_ID"),
+          clientSecret: secret("FEIDE_CLIENT_SECRET"),
+          issuerUrl: "https://auth.dataporten.no",
+          scopes: ["openid", "profile", "userid", "email"],
+        },
+      ],
+      callbackUrls: [
+        "http://localhost:3000/",
+        "http://localhost:3000/profile",
+        "https://main.deodkfzpv9kfw.amplifyapp.com/",
+        "https://main.deodkfzpv9kfw.amplifyapp.com/profile"
+      ],
+      logoutUrls: [
+        "http://localhost:3000/",
+        "http://localhost:3000/logout",
+        "https://main.deodkfzpv9kfw.amplifyapp.com/",
+        "https://main.deodkfzpv9kfw.amplifyapp.com/logout"
+      ],
+    },
   },
   // Define the admin group
   groups: ["admin"],


### PR DESCRIPTION
## Changes
- Added production callback URLs for main.deodkfzpv9kfw.amplifyapp.com
- Added production logout URLs to auth/resource.ts

## Why
- Enables OAuth/Feide authentication in production deployment
- Fixes Infrastructure as Code configuration for production OAuth
- Allows Cognito to automatically create a domain for production user pool

## Testing
- OAuth configuration tested in local sandbox
- Production URLs match the deployed application domain